### PR TITLE
fix for NaN result

### DIFF
--- a/xirr.go
+++ b/xirr.go
@@ -9,7 +9,7 @@ func XIRR(payments []Payment) RateInfo {
 	var startDate, finishDate = findStartAndFinishDates(payments)
 	var totalYears = YearsBetween(startDate, finishDate)
 	var yearCashflows = convertToCashflows(payments, startDate)
-	var annualRate = calculateXirr(yearCashflows, 0, 1e6, 1e-4)
+	var annualRate = calculateXirr(yearCashflows, 1e-6, 1e6, 1e-4)
 	var rate = math.Pow(annualRate, totalYears)
 	return RateInfo{
 		StartDate:  startDate,


### PR DESCRIPTION
on arm64 math.Pow behaves differently than on x64 when the interestRate is 0, returning +Inf, that then ends up generating a NaN when multiplied-added; avoid the problem by not using an interestRate of 0